### PR TITLE
Fix backend and frontend script paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,8 @@ import requests
 import json
 
 # Paths to your scripts
-BACKEND_SCRIPT = "server/app.py"
-FRONTEND_SCRIPT = "client/app.py"
+BACKEND_SCRIPT = "server/APP.py"
+FRONTEND_SCRIPT = "client/APP.py"
 
 # Log file paths
 BACKEND_LOG = "backend.log"

--- a/main.spec
+++ b/main.spec
@@ -8,8 +8,8 @@ a = Analysis(
     pathex=['.'],
     binaries=[],
     datas=[
-        ('server/app.py', 'server'),
-        ('client/app.py', 'client'),
+        ('server/APP.py', 'server'),
+        ('client/APP.py', 'client'),
         ('ngrok.yml', '.')
     ],
     hiddenimports=[],


### PR DESCRIPTION
## Summary
- correct paths to backend and frontend scripts in `main.py`
- update `main.spec` to match new script names

## Testing
- `python -m py_compile main.py`
- `python -m py_compile server/APP.py client/APP.py`


------
https://chatgpt.com/codex/tasks/task_e_68403a17706083289f5ac818e20b00c7